### PR TITLE
Unindent continuous_mean_std buffer

### DIFF
--- a/tab_transformer_pytorch/tab_transformer_pytorch.py
+++ b/tab_transformer_pytorch/tab_transformer_pytorch.py
@@ -170,7 +170,7 @@ class TabTransformer(nn.Module):
 
         if exists(continuous_mean_std):
             assert continuous_mean_std.shape == (num_continuous, 2), f'continuous_mean_std must have a shape of ({num_continuous}, 2) where the last dimension contains the mean and variance respectively'
-            self.register_buffer('continuous_mean_std', continuous_mean_std)
+        self.register_buffer('continuous_mean_std', continuous_mean_std)
 
         self.norm = nn.LayerNorm(num_continuous)
         self.num_continuous = num_continuous


### PR DESCRIPTION
Problem: `continuous_mean_std ` is not an attribute of `TabTransformer` if not defined in the argument explicitly.
Example reproducing `AttributeError`:
```
model = TabTransformer(
    categories = (10, 5, 6, 5, 8),      # tuple containing the number of unique values within each category
    num_continuous = 10,                # number of continuous values
    dim = 32,                           # dimension, paper set at 32
    dim_out = 1,                        # binary prediction, but could be anything
    depth = 6,                          # depth, paper recommended 6
    heads = 8,                          # heads, paper recommends 8
    attn_dropout = 0.1,                 # post-attention dropout
    ff_dropout = 0.1,                   # feed forward dropout
    mlp_hidden_mults = (4, 2),          # relative multiples of each hidden dimension of the last mlp to logits
    mlp_act = nn.ReLU(),                # activation for final mlp, defaults to relu, but could be anything else (selu etc)
# continuous_mean_std = cont_mean_std # (optional) - normalize the continuous values before layer norm)
x_categ = torch.randint(0, 5, (1, 5))     # category values, from 0 - max number of categories, in the order as passed into the constructor above
x_cont = torch.randn(1, 10)               # assume continuous values are already normalized individually
pred = model(x_categ, x_cont) # gives AttributeError

 ```
Solution: Simply un-indenting the buffer registration of `continuous_mean_std`.