### PR TITLE
Update tab_transformer_pytorch.py

### DIFF
--- a/tab_transformer_pytorch/tab_transformer_pytorch.py
+++ b/tab_transformer_pytorch/tab_transformer_pytorch.py
@@ -119,8 +119,8 @@ class MLP(nn.Module):
             if is_last:
                 continue
 
-            act = default(act, nn.ReLU())
-            layers.append(act)
+        act = default(act, nn.ReLU())
+        layers.append(act)
 
         self.mlp = nn.Sequential(*layers)
 


### PR DESCRIPTION
Add activation function out of the loop for the whole model, not after each of the linear layers. 'if is_last' condition was creating linear output all the time no matter what the activation function was.