### PR TITLE
Support either no categorical or no continuous input 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
   name = 'tab-transformer-pytorch',
   packages = find_packages(),
-  version = '0.2.0',
+  version = '0.2.1',
   license='MIT',
   description = 'Tab Transformer - Pytorch',
   author = 'Phil Wang',


### PR DESCRIPTION
Hey @lucidrains, thanks for this implementation!

I've got a use case where there are no incoming categorical inputs, as the broader ML pipeline has already featurized everything into numerical/continuous input.

I stumbled upon some issues while trying that, and so this PR contains some (hopefully, simple) changes I made for this to work with both `TabTransformer` and `FTTransformer` classes. I've added the same logic for the opposite use case (all categorical, no continuous input). Hopefully this can be of use to other users as well.


Modified example calls:

a) No continuous features:
```python
model = TabTransformer(
    categories = (10, 5, 6, 5, 8),
    num_continuous = 0,
    [...]
)

x_categ = torch.randint(0, 5, (1, 5))
x_cont = torch.tensor([[]])
pred = model(x_categ, x_cont)
```

No categories:
```python
model = TabTransformer(
    categories = tuple(),
    num_continuous = 10,
    [...]
)

x_categ = torch.tensor([])
x_cont = torch.randn(1, 10)
pred = model(x_categ, x_cont)
```

EDIT: Just now do I realize this is very much related to #3.